### PR TITLE
Example integration isInteractive fixed.

### DIFF
--- a/example/lib/chess_board_with_history.dart
+++ b/example/lib/chess_board_with_history.dart
@@ -132,7 +132,7 @@ class _ChessBoardWithHistoryState extends State<ChessBoardWithHistory> {
                   cellHighlights: {},
                   showPossibleMoves: true,
                   // Board is only interactive when we're at the current position
-                  isInteractive: _customFen == null,
+                  isInteractive: _moveHistory.canGoForward == false,
                   // Customize the non-interactive overlay
                   nonInteractiveText: 'ANALYZING POSITION',
                   nonInteractiveTextStyle: const TextStyle(


### PR DESCRIPTION
The previous logic (`_customFen == null`) had an issue:
- Board was interactive when `_customFen` was null (current position)
- But users expect to make moves when they're at the **latest** position in history
- If user navigated back and then forward to the end, `_customFen` wasn't null but they should be able to move

### **New Logic**
- `!_moveHistory.canGoForward` means we're at the latest position in history
- Users can only make moves when at the latest position
- This prevents moves in middle of history while allowing moves at current game state
